### PR TITLE
Adds php7-gmp to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --update --no-cache add \
     php7-fileinfo \
     php7-fpm \
     php7-gd \
+    php7-gmp \
     php7-iconv \
     php7-intl \
     php7-json \


### PR DESCRIPTION
Hi, is it a problem if we add php7-gmp directly in the dockerfile? It is used by some extensions like https://github.com/askvortsov1/flarum-pwa