### PR TITLE
fix: caching_sha2_password support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk --update --no-cache add \
     curl \
     libgd \
     mysql-client \
+    mariadb-connector-c \
     nginx \
     php82 \
     php82-cli \


### PR DESCRIPTION
If you have a database with `sha2` passwords instead of `mysql_native_password` you need this plugin otherwise the install and database connection flow breaks.