### PR TITLE
Start crond and add a crontab to run the Flarum Scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG FLARUM_VERSION=v1.8.10
+ARG FLARUM_VERSION=v1.8.14
 ARG ALPINE_VERSION=3.22
 
 FROM tianon/gosu:latest AS gosu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG FLARUM_VERSION=v1.8.14
+ARG FLARUM_VERSION=v1.8.16
 ARG ALPINE_VERSION=3.22
 
 FROM tianon/gosu:latest AS gosu

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -16,3 +16,11 @@ s6-setuidgid ${PUID}:${PGID}
 php-fpm83 -F
 EOL
 chmod +x /etc/services.d/php-fpm/run
+
+mkdir -p /etc/services.d/cron
+cat > /etc/services.d/cron/run <<EOL
+#!/usr/bin/execlineb -P
+s6-setuidgid 0:0
+crond -f
+EOL
+chmod +x /etc/services.d/cron/run

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -21,6 +21,6 @@ mkdir -p /etc/services.d/cron
 cat > /etc/services.d/cron/run <<EOL
 #!/usr/bin/execlineb -P
 s6-setuidgid 0:0
-crond -f
+crond -f -L /dev/stdout
 EOL
 chmod +x /etc/services.d/cron/run

--- a/rootfs/etc/crontabs/flarum
+++ b/rootfs/etc/crontabs/flarum
@@ -1,0 +1,3 @@
+# Execute the Flarum Scheduler
+# min   hour    day     month   weekday command
+*       *       *       *       *       cd /opt/flarum && php flarum schedule:run >> /dev/null 2>&1

--- a/rootfs/etc/crontabs/flarum
+++ b/rootfs/etc/crontabs/flarum
@@ -1,3 +1,3 @@
 # Execute the Flarum Scheduler
 # min   hour    day     month   weekday command
-*       *       *       *       *       cd /opt/flarum && php flarum schedule:run >> /dev/null 2>&1
+*       *       *       *       *       cd /opt/flarum && php flarum schedule:run >> /proc/self/fd/1 2>> /proc/self/fd/2


### PR DESCRIPTION
In order for some Flarum Extensions to work correctly, the scheduler must be invoked by CRON.

This PR adds an S6 service to exexute `crond -f` as root, and adds a crontab with the required content to execute the scheduler. (Based on https://discuss.flarum.org/d/24118-setup-the-flarum-scheduler-using-cron)