### PR TITLE
Flarum 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG FLARUM_VERSION=v1.8.10
+ARG FLARUM_VERSION=v2.0.0-beta.8
 ARG ALPINE_VERSION=3.22
 
 FROM tianon/gosu:latest AS gosu
@@ -55,8 +55,8 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS="2"\
 ARG FLARUM_VERSION
 RUN mkdir -p /opt/flarum \
   && curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
-  && COMPOSER_CACHE_DIR="/tmp" composer create-project flarum/flarum /opt/flarum --no-install \
-  && COMPOSER_CACHE_DIR="/tmp" composer require --working-dir /opt/flarum flarum/core:${FLARUM_VERSION} \
+  && COMPOSER_CACHE_DIR="/tmp" composer create-project flarum/flarum /opt/flarum --stability=beta --no-install \
+  && COMPOSER_CACHE_DIR="/tmp" composer require --working-dir /opt/flarum -W flarum/core:${FLARUM_VERSION} \
   && composer clear-cache \
   && addgroup -g ${PGID} flarum \
   && adduser -D -h /opt/flarum -u ${PUID} -G flarum -s /bin/sh -D flarum \

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -44,7 +44,6 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
-      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -2,10 +2,10 @@ name: flarum
 
 services:
   db:
-    image: mariadb:10
+    image: mariadb:11
     container_name: flarum_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"
     volumes:
@@ -44,6 +44,7 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
+      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/examples/subfolder/compose.yml
+++ b/examples/subfolder/compose.yml
@@ -84,7 +84,6 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
-      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/examples/subfolder/compose.yml
+++ b/examples/subfolder/compose.yml
@@ -36,10 +36,10 @@ services:
     restart: always
 
   db:
-    image: mariadb:10
+    image: mariadb:11
     container_name: flarum_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"
     volumes:
@@ -84,6 +84,7 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
+      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -86,7 +86,6 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
-      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -36,10 +36,10 @@ services:
     restart: always
 
   db:
-    image: mariadb:10
+    image: mariadb:11
     container_name: flarum_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"
     volumes:
@@ -86,6 +86,7 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
+      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -60,6 +60,7 @@ DB_NAME=${DB_NAME:-flarum}
 DB_USER=${DB_USER:-flarum}
 #DB_PASSWORD=${DB_PASSWORD:-asupersecretpassword}
 DB_PREFIX=${DB_PREFIX:-flarum_}
+DB_DRIVER=${DB_DRIVER:-mysql}
 DB_NOPREFIX=${DB_NOPREFIX:-false}
 DB_TIMEOUT=${DB_TIMEOUT:-60}
 
@@ -151,7 +152,7 @@ if [ "${counttables}" -eq "0" ]; then
 debug: ${FLARUM_DEBUG}
 baseUrl: ${FLARUM_BASE_URL}
 databaseConfiguration:
-  driver: mysql
+  driver: ${DB_DRIVER}
   host: ${DB_HOST}
   database: ${DB_NAME}
   username: ${DB_USER}
@@ -180,7 +181,7 @@ gosu flarum:flarum cat >/opt/flarum/config.php <<EOL
   'debug' => ${FLARUM_DEBUG},
   'database' =>
   array (
-    'driver' => 'mysql',
+    'driver' => '${DB_DRIVER}',
     'host' => '${DB_HOST}',
     'port' => ${DB_PORT},
     'database' => '${DB_NAME}',
@@ -217,7 +218,7 @@ if [ -s "/data/extensions/list" ]; then
     extensions="${extensions}${extension} "
   done </data/extensions/list
   echo "Installing additional extensions..."
-  COMPOSER_CACHE_DIR="/data/extensions/.cache" gosu flarum:flarum composer require --working-dir /opt/flarum ${extensions}
+  COMPOSER_CACHE_DIR="/data/extensions/.cache" gosu flarum:flarum composer require --working-dir /opt/flarum -W ${extensions}
 fi
 
 gosu flarum:flarum php flarum migrate

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -60,7 +60,6 @@ DB_NAME=${DB_NAME:-flarum}
 DB_USER=${DB_USER:-flarum}
 #DB_PASSWORD=${DB_PASSWORD:-asupersecretpassword}
 DB_PREFIX=${DB_PREFIX:-flarum_}
-DB_DRIVER=${DB_DRIVER:-mysql}
 DB_NOPREFIX=${DB_NOPREFIX:-false}
 DB_TIMEOUT=${DB_TIMEOUT:-60}
 
@@ -139,6 +138,15 @@ while ! ${dbcmd} -e "show databases;" >/dev/null 2>&1; do
   fi
 done
 echo "Database ready!"
+
+# Auto-detect database driver from server version
+DB_DRIVER="mysql"
+SERVER_VERSION=$(${dbcmd} -N -s -e "SELECT VERSION();" 2>/dev/null)
+if echo "$SERVER_VERSION" | grep -qi "mariadb"; then
+  DB_DRIVER="mariadb"
+fi
+echo "Detected database driver: ${DB_DRIVER} (${SERVER_VERSION})"
+
 counttables=$(echo 'SHOW TABLES' | ${dbcmd} "$DB_NAME" | wc -l)
 
 # Enforce no prefix for db

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -34,7 +34,6 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
-      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -2,10 +2,10 @@ name: flarum
 
 services:
   db:
-    image: mariadb:10
+    image: mariadb:11
     container_name: flarum_db
     command:
-      - "mysqld"
+      - "mariadbd"
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"
     volumes:
@@ -34,6 +34,7 @@ services:
       - "PUID"
       - "PGID"
       - "DB_HOST=db"
+      - "DB_DRIVER=mariadb"
       - "DB_NAME=${MYSQL_DATABASE}"
       - "DB_USER=${MYSQL_USER}"
       - "DB_PASSWORD=${MYSQL_PASSWORD}"


### PR DESCRIPTION
Closes #143

- Bump Flarum to v2.0.0-beta.8
- Add `--stability=beta` and `-W` flags for Composer
- Auto-detect `mysql` vs `mariadb` database driver from server version
- Update MariaDB to 11.x (`mariadbd` replaces `mysqld`)
