### PR TITLE
fix: sync /data/extensions/list when an extension is added or removed…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN mkdir -p /opt/flarum \
   && composer clear-cache \
   && addgroup -g ${PGID} flarum \
   && adduser -D -h /opt/flarum -u ${PUID} -G flarum -s /bin/sh -D flarum \
+  && composer show --working-dir /opt/flarum --direct --name-only | sort > /opt/flarum/.bundled-packages \
   && chown -R flarum:flarum /opt/flarum \
   && rm -rf /root/.composer /tmp/*
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -220,5 +220,11 @@ if [ -s "/data/extensions/list" ]; then
   COMPOSER_CACHE_DIR="/data/extensions/.cache" gosu flarum:flarum composer require --working-dir /opt/flarum ${extensions}
 fi
 
+# Register composer hook so that extensions installed via the admin UI
+# (Extension Manager) are automatically persisted to /data/extensions/list
+# (see https://github.com/crazy-max/docker-flarum/issues/103)
+echo "Registering extension sync hook..."
+gosu flarum:flarum composer config --working-dir /opt/flarum scripts.post-update-cmd extension-sync
+
 gosu flarum:flarum php flarum migrate
 gosu flarum:flarum php flarum cache:clear

--- a/rootfs/usr/local/bin/extension-sync
+++ b/rootfs/usr/local/bin/extension-sync
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Sync /data/extensions/list with composer.json so that extensions
+# installed via the admin UI (Extension Manager) persist across restarts.
+
+php -r '
+$bundled = file("/opt/flarum/.bundled-packages", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+$composer = json_decode(file_get_contents("/opt/flarum/composer.json"), true);
+$packages = array_filter(array_keys($composer["require"]), fn($p) => str_contains($p, "/"));
+$extensions = array_diff($packages, $bundled);
+sort($extensions);
+file_put_contents("/data/extensions/list", implode("\n", $extensions) . "\n");
+'


### PR DESCRIPTION
Fixes #118
I tried to be as minimal as possible, I have tested locally and /data/extensions/list is synced when the user adds / remove an extension