### PR TITLE
flarum scheduler sidecar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ___
 * [Environment variables](#environment-variables)
   * [General](#general)
   * [Flarum](#flarum)
+  * [Sidecar cron](#sidecar-cron)
   * [Database](#database)
 * [Volumes](#volumes)
 * [Ports](#ports)
@@ -35,6 +36,7 @@ ___
 * [Upgrade](#upgrade)
 * [Notes](#notes)
   * [First launch](#first-launch)
+  * [Scheduler](#scheduler)
   * [Manage extensions](#manage-extensions)
   * [Sending mails with SMTP](#sending-mails-with-smtp)
 * [Contributing](#contributing)
@@ -44,6 +46,7 @@ ___
 
 * Run as non-root user
 * Multi-platform image
+* Cron tasks to run the Flarum scheduler as a "sidecar" container
 * [s6-overlay](https://github.com/just-containers/s6-overlay/) as process supervisor
 * [msmtpd SMTP relay](https://github.com/crazy-max/docker-msmtpd) image to send emails
 * [Traefik](https://github.com/containous/traefik-library-image) as reverse proxy and creation/renewal of Let's Encrypt certificates (see [this template](examples/traefik))
@@ -107,6 +110,14 @@ linux/arm64
 * `FLARUM_REFERRER_POLICY`: Referrer policy (default `same-origin`)
 * `FLARUM_COOKIE_SAMESITE`: Set `SameSite` attribute of `Set-Cookie` (default `lax`)
 * `FLARUM_ANNOUNCEMENTS_DISABLED`: Disable Flarum announcements on the admin dashboard (default `false`)
+
+### Sidecar cron
+
+The following environment variables are only used if you run the container as
+["sidecar" cron mode](#scheduler):
+
+* `SIDECAR_CRON`: Set to `1` to enable sidecar cron mode (default `0`)
+* `CRON_SCHEDULE`: Periodically execute Flarum scheduler (default `* * * * *`)
 
 ### Database
 
@@ -182,6 +193,28 @@ On first launch, an initial administrator user will be created:
 | Login    | Password |
 |----------|----------|
 | `flarum` | `flarum` |
+
+### Scheduler
+
+Flarum scheduled tasks can be run with a "sidecar" container like in the
+[compose file](examples/compose/compose.yml). The sidecar uses the same image,
+database environment, and `/data` volume as the main `flarum` service, but only
+runs cron:
+
+```bash
+docker run -d --name flarum_cron \
+  -v $(pwd)/data:/data \
+  -e "DB_HOST=db" \
+  -e "DB_NAME=flarum" \
+  -e "DB_USER=flarum" \
+  -e "DB_PASSWORD=flarum" \
+  -e "FLARUM_BASE_URL=http://127.0.0.1:8000" \
+  -e "SIDECAR_CRON=1" \
+  crazymax/flarum:latest
+```
+
+Run only one cron sidecar per Flarum installation. The default
+`CRON_SCHEDULE` runs `php flarum schedule:run` every minute.
 
 ### Manage extensions
 

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -50,3 +50,24 @@ services:
     env_file:
       - "./flarum.env"
     restart: always
+
+  cron:
+    image: crazymax/flarum:latest
+    container_name: flarum_cron
+    depends_on:
+      - flarum
+    volumes:
+      - "./data:/data"
+    environment:
+      - "TZ"
+      - "PUID"
+      - "PGID"
+      - "DB_HOST=db"
+      - "DB_NAME=${MYSQL_DATABASE}"
+      - "DB_USER=${MYSQL_USER}"
+      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "SIDECAR_CRON=1"
+      - "CRON_SCHEDULE=* * * * *"
+    env_file:
+      - "./flarum.env"
+    restart: always

--- a/examples/subfolder/compose.yml
+++ b/examples/subfolder/compose.yml
@@ -90,3 +90,26 @@ services:
     env_file:
       - "./flarum.env"
     restart: always
+
+  cron:
+    image: crazymax/flarum:latest
+    container_name: flarum_cron
+    depends_on:
+      - flarum
+    volumes:
+      - "./data:/data"
+    environment:
+      - "TZ"
+      - "PUID"
+      - "PGID"
+      - "DB_HOST=db"
+      - "DB_NAME=${MYSQL_DATABASE}"
+      - "DB_USER=${MYSQL_USER}"
+      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "SIDECAR_CRON=1"
+      - "CRON_SCHEDULE=* * * * *"
+    env_file:
+      - "./flarum.env"
+    healthcheck:
+      disable: true
+    restart: always

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -92,3 +92,26 @@ services:
     env_file:
       - "./flarum.env"
     restart: always
+
+  cron:
+    image: crazymax/flarum:latest
+    container_name: flarum_cron
+    depends_on:
+      - flarum
+    volumes:
+      - "./data:/data"
+    environment:
+      - "TZ"
+      - "PUID"
+      - "PGID"
+      - "DB_HOST=db"
+      - "DB_NAME=${MYSQL_DATABASE}"
+      - "DB_USER=${MYSQL_USER}"
+      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "SIDECAR_CRON=1"
+      - "CRON_SCHEDULE=* * * * *"
+    env_file:
+      - "./flarum.env"
+    healthcheck:
+      disable: true
+    restart: always

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -44,6 +44,7 @@ LISTEN_IPV6=${LISTEN_IPV6:-true}
 REAL_IP_FROM=${REAL_IP_FROM:-0.0.0.0/32}
 REAL_IP_HEADER=${REAL_IP_HEADER:-X-Forwarded-For}
 LOG_IP_VAR=${LOG_IP_VAR:-remote_addr}
+SIDECAR_CRON=${SIDECAR_CRON:-0}
 
 FLARUM_DEBUG=${FLARUM_DEBUG:-false}
 #FLARUM_BASE_URL=${FLARUM_BASE_URL:-http://flarum.docker}
@@ -146,6 +147,20 @@ if [ "$DB_NOPREFIX" = "true" ]; then
   DB_PREFIX=""
 fi
 
+if [ "${counttables}" -eq "0" ] && [ "$SIDECAR_CRON" = "1" ]; then
+  echo "Sidecar cron mode detected, waiting ${DB_TIMEOUT}s for Flarum to be installed..."
+  counter=1
+  while [ "${counttables}" -eq "0" ]; do
+    sleep 1
+    counter=$((counter + 1))
+    if [ ${counter} -gt ${DB_TIMEOUT} ]; then
+      echo >&2 "ERROR: Flarum is not installed yet"
+      exit 1
+    fi
+    counttables=$(echo 'SHOW TABLES' | ${dbcmd} "$DB_NAME" | wc -l)
+  done
+fi
+
 if [ "${counttables}" -eq "0" ]; then
   echo "First install detected..."
   gosu flarum:flarum cat >/tmp/config.yml <<EOL
@@ -212,6 +227,11 @@ gosu flarum:flarum cat >/opt/flarum/config.php <<EOL
   'flarum_announcements.disabled' => ${FLARUM_ANNOUNCEMENTS_DISABLED},
 );
 EOL
+
+if [ "$SIDECAR_CRON" = "1" ]; then
+  echo "Sidecar cron mode detected, skipping Flarum maintenance tasks..."
+  exit 0
+fi
 
 if [ -s "/data/extensions/list" ]; then
   while read extension; do

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+SIDECAR_CRON=${SIDECAR_CRON:-0}
+
+if [ "$SIDECAR_CRON" = "1" ]; then
+  exit 0
+fi
+
 mkdir -p /etc/services.d/nginx
 cat > /etc/services.d/nginx/run <<EOL
 #!/usr/bin/execlineb -P

--- a/rootfs/etc/cont-init.d/05-svc-cron.sh
+++ b/rootfs/etc/cont-init.d/05-svc-cron.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/with-contenv sh
+# shellcheck shell=sh
+
+CRONTAB_PATH="/var/spool/cron/crontabs"
+SIDECAR_CRON=${SIDECAR_CRON:-0}
+CRON_SCHEDULE="${CRON_SCHEDULE-* * * * *}"
+
+if [ "$SIDECAR_CRON" != "1" ]; then
+  exit 0
+fi
+
+echo ">>"
+echo ">> Sidecar cron container detected for Flarum"
+echo ">>"
+
+rm -rf "${CRONTAB_PATH}"
+mkdir -p "${CRONTAB_PATH}"
+touch "${CRONTAB_PATH}/flarum"
+
+if [ -n "$CRON_SCHEDULE" ]; then
+  echo "Creating Flarum scheduler cron task with the following period fields: $CRON_SCHEDULE"
+  echo "${CRON_SCHEDULE} sh /usr/local/bin/flarum_scheduler" >>"${CRONTAB_PATH}/flarum"
+else
+  echo "CRON_SCHEDULE env var empty..."
+fi
+
+chmod 0755 "${CRONTAB_PATH}"
+chmod 0644 "${CRONTAB_PATH}/flarum"
+
+mkdir -p /etc/services.d/cron
+cat >/etc/services.d/cron/run <<EOL
+#!/usr/bin/execlineb -P
+with-contenv
+exec busybox crond -f -L /dev/stdout -c ${CRONTAB_PATH}
+EOL
+chmod +x /etc/services.d/cron/run

--- a/rootfs/usr/local/bin/flarum_scheduler
+++ b/rootfs/usr/local/bin/flarum_scheduler
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+cd /opt/flarum || exit 1
+
+if [ "$(id -u)" -eq 0 ]; then
+  exec gosu flarum:flarum php flarum schedule:run --no-interaction
+fi
+
+exec php flarum schedule:run --no-interaction

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -40,3 +40,24 @@ services:
     env_file:
       - "./flarum.env"
     restart: always
+
+  cron:
+    image: ${FLARUM_IMAGE:-crazymax/flarum}
+    container_name: flarum_cron
+    depends_on:
+      - flarum
+    volumes:
+      - "./data:/data"
+    environment:
+      - "TZ"
+      - "PUID"
+      - "PGID"
+      - "DB_HOST=db"
+      - "DB_NAME=${MYSQL_DATABASE}"
+      - "DB_USER=${MYSQL_USER}"
+      - "DB_PASSWORD=${MYSQL_PASSWORD}"
+      - "SIDECAR_CRON=1"
+      - "CRON_SCHEDULE=* * * * *"
+    env_file:
+      - "./flarum.env"
+    restart: always


### PR DESCRIPTION
closes #134 

This adds an optional cron sidecar mode for running Flarum scheduled tasks without starting the web services in the same container.

Flarum expects [`schedule:run`](https://docs.flarum.org/console#schedule) to be executed regularly so extensions can run scheduled work, but running cron inside every web container would duplicate jobs when the app is scaled. A sidecar keeps the scheduler as a separate runtime decision.