### PR TITLE
persist extension requirements from Composer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,19 @@ jobs:
           log_check: "ready to handle connections"
           timeout: 120
       -
+        name: Check extension persistence
+        run: |
+          set -eux
+          docker compose exec -T -u flarum flarum sh -lc 'cd /opt/flarum && COMPOSER_CACHE_DIR=/data/extensions/.cache composer require "flarum/extension-manager:*"'
+          docker compose exec -T flarum sh -lc 'extension list | grep -Fx "flarum/extension-manager:*"'
+          docker compose up -d --force-recreate --no-deps flarum
+          timeout 180 sh -c 'until docker compose exec -T flarum sh -lc "composer show --working-dir /opt/flarum flarum/extension-manager >/dev/null 2>&1"; do sleep 5; done'
+          docker compose exec -T flarum sh -lc 'extension list | grep -Fx "flarum/extension-manager:*"'
+        working-directory: test
+        env:
+          FLARUM_IMAGE: ${{ env.BUILD_TAG }}
+          FLARUM_CONTAINER: ${{ env.CONTAINER_NAME }}
+      -
         name: Logs
         if: always()
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY --from=gosu /gosu /usr/local/bin/
 RUN apk --update --no-cache add \
     bash \
     curl \
+    jq \
     libgd \
     mysql-client \
     mariadb-connector-c \

--- a/README.md
+++ b/README.md
@@ -218,58 +218,49 @@ Run only one cron sidecar per Flarum installation. The default
 
 ### Manage extensions
 
-You can install [Flarum extensions](https://extiverse.com/) from the command line using a
-[specially crafted script](rootfs/usr/local/bin/extension) with this image:
+This image does not persist `/opt/flarum/composer.json`, `composer.lock`, or
+`vendor`. Instead, additional direct Composer requirements are persisted in
+`/data/extensions/list` and reinstalled when the container starts.
 
-`docker compose exec flarum extension require <package> [<package> ...]`
+Extensions installed or removed through Flarum's Extension Manager are
+synchronized to `/data/extensions/list` automatically. You can also manage
+[Flarum extensions](https://docs.flarum.org/extensions/) from the command line
+using the helper script included with this image:
+
+```shell
+docker compose exec flarum extension require <package> [<package> ...]
+```
+
+If no version constraint is provided, the helper requires `<package>:*`, which
+matches Flarum's recommendation for extensions that should track the latest
+version compatible with the installed Flarum core.
 
 To remove one or more extensions:
 
-`docker compose exec flarum extension remove <package> [<package> ...]`
+```shell
+docker compose exec flarum extension remove <package> [<package> ...]
+```
+
+If you run Composer manually with scripts disabled, synchronize the persisted
+extension list afterwards:
+
+```shell
+docker compose exec flarum extension sync
+```
 
 To list all extensions:
 
-`docker compose exec flarum extension list`
+```shell
+docker compose exec flarum extension list
+```
 
 Example with [`fof/upload`](https://extiverse.com/extension/fof/upload) extension:
 
-```
+```shell
 $ docker compose exec flarum extension require fof/upload
-Using version ^1.0 for fof/upload
-./composer.json has been updated
-Running composer update fof/upload
-Loading composer repositories with package information
-Updating dependencies
-Lock file operations: 5 installs, 0 updates, 0 removals
-  - Locking fof/upload (1.0.0)
-  - Locking guzzlehttp/guzzle (7.3.0)
-  - Locking guzzlehttp/promises (1.4.1)
-  - Locking psr/http-client (1.0.1)
-  - Locking softcreatr/php-mime-detector (3.2.0)
-Writing lock file
-Installing dependencies from lock file (including require-dev)
-Package operations: 5 installs, 0 updates, 0 removals
-  - Downloading softcreatr/php-mime-detector (3.2.0)
-  - Downloading psr/http-client (1.0.1)
-  - Downloading guzzlehttp/promises (1.4.1)
-  - Downloading guzzlehttp/guzzle (7.3.0)
-  - Downloading fof/upload (1.0.0)
-  - Installing softcreatr/php-mime-detector (3.2.0): Extracting archive
-  - Installing psr/http-client (1.0.1): Extracting archive
-  - Installing guzzlehttp/promises (1.4.1): Extracting archive
-  - Installing guzzlehttp/guzzle (7.3.0): Extracting archive
-  - Installing fof/upload (1.0.0): Extracting archive
-2 package suggestions were added by new dependencies, use `composer suggest` to see details.
-Generating autoload files
-70 packages you are using are looking for funding.
-Use the `composer fund` command to find out more!
-fof/upload extension added
-Clearing the cache...
+$ docker compose exec flarum extension list
+fof/upload:*
 ```
-
-> [!WARNING]
-> You cannot use [Bazaar marketplace extension](https://discuss.flarum.org/d/5151-bazaar-the-extension-marketplace)
-> to install extensions for now.
 
 ### Sending mails with SMTP
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -110,6 +110,10 @@ ln -sf /data/storage /opt/flarum/storage
 chown -h flarum:flarum /opt/flarum/extensions /opt/flarum/public/assets /opt/flarum/storage
 fixperms /data/assets /data/extensions /data/storage /opt/flarum/vendor
 
+echo "Configuring extension persistence..."
+gosu flarum:flarum sh /usr/local/bin/extension install-hook
+gosu flarum:flarum sh /usr/local/bin/extension baseline
+
 echo "Checking parameters..."
 if [ -z "$FLARUM_BASE_URL" ]; then
   echo >&2 "ERROR: FLARUM_BASE_URL must be defined"
@@ -234,12 +238,20 @@ if [ "$SIDECAR_CRON" = "1" ]; then
 fi
 
 if [ -s "/data/extensions/list" ]; then
-  while read extension; do
+  extensions=()
+  while IFS= read -r extension; do
+    extension="${extension#"${extension%%[![:space:]]*}"}"
+    extension="${extension%"${extension##*[![:space:]]}"}"
     test -z "${extension}" && continue
-    extensions="${extensions}${extension} "
+    [[ "${extension}" == \#* ]] && continue
+    extensions+=("${extension}")
   done </data/extensions/list
-  echo "Installing additional extensions..."
-  COMPOSER_CACHE_DIR="/data/extensions/.cache" gosu flarum:flarum composer require --working-dir /opt/flarum ${extensions}
+
+  if [ "${#extensions[@]}" -gt 0 ]; then
+    echo "Installing additional extensions..."
+    COMPOSER_CACHE_DIR="/data/extensions/.cache" gosu flarum:flarum composer require --working-dir /opt/flarum "${extensions[@]}"
+    gosu flarum:flarum sh /usr/local/bin/extension sync
+  fi
 fi
 
 gosu flarum:flarum php flarum migrate

--- a/rootfs/usr/local/bin/extension
+++ b/rootfs/usr/local/bin/extension
@@ -1,47 +1,186 @@
 #!/usr/bin/env sh
 set -e
 
-EXTS_CACHE_DIR=/data/extensions/.cache
-EXTS_LIST=/data/extensions/list
+HOOK_COMMAND="sh /usr/local/bin/extension sync"
 
-cd /opt/flarum/ || exit
-action=${1}
+BASE_PATH="${FLARUM_EXTENSION_BASE:-/opt/flarum}"
+EXTS_CACHE_DIR="${FLARUM_EXTENSION_CACHE:-/data/extensions/.cache}"
+LIST_PATH="${FLARUM_EXTENSION_LIST:-/data/extensions/list}"
+BASELINE_PATH="${FLARUM_EXTENSION_BASELINE:-${BASE_PATH}/.docker-flarum-base-extensions}"
+COMPOSER_JSON="${BASE_PATH}/composer.json"
+
+usage() {
+  echo "Usage:"
+  echo "extension require <package> [<package>...]"
+  echo "extension remove <package> [<package>...]"
+  echo "extension sync"
+  echo "extension list"
+}
+
+run_as_flarum() {
+  if [ "$(id -u)" -eq 0 ]; then
+    gosu flarum:flarum "$@"
+  else
+    "$@"
+  fi
+}
+
+composer_require() {
+  if [ "$(id -u)" -eq 0 ]; then
+    COMPOSER_CACHE_DIR="${EXTS_CACHE_DIR}" gosu flarum:flarum composer require "$@"
+  else
+    COMPOSER_CACHE_DIR="${EXTS_CACHE_DIR}" composer require "$@"
+  fi
+}
+
+composer_remove() {
+  if [ "$(id -u)" -eq 0 ]; then
+    COMPOSER_CACHE_DIR="${EXTS_CACHE_DIR}" gosu flarum:flarum composer remove "$@"
+  else
+    COMPOSER_CACHE_DIR="${EXTS_CACHE_DIR}" composer remove "$@"
+  fi
+}
+
+sync_as_flarum() {
+  if [ "$(id -u)" -eq 0 ]; then
+    gosu flarum:flarum sh /usr/local/bin/extension sync
+  else
+    sync_list
+  fi
+}
+
+direct_package_names() {
+  jq -r '(.require // {}) | keys[] | select(. != "flarum/core")' "${COMPOSER_JSON}" | sort -u
+}
+
+direct_package_specs() {
+  jq -r '
+    (.require // {}) | to_entries[] | select(.key != "flarum/core") |
+    "\(.key):\(if (.value | type) == "string" and (.value | length) > 0 then .value else "*" end)"
+  ' "${COMPOSER_JSON}" | sort -u
+}
+
+install_hook() {
+  dir=$(dirname "${COMPOSER_JSON}")
+  tmp=$(mktemp -p "${dir}" composer.json.XXXXXX)
+
+  jq --arg cmd "${HOOK_COMMAND}" '
+    .scripts = (.scripts // {}) |
+    (.scripts["post-install-cmd"] // []) as $install |
+    (.scripts["post-update-cmd"] // []) as $update |
+    .scripts["post-install-cmd"] = (
+      (if ($install | type) == "array" then $install
+      elif ($install | type) == "string" then [$install]
+      else [] end) as $commands |
+      if ($commands | index($cmd)) then $commands else $commands + [$cmd] end
+    ) |
+    .scripts["post-update-cmd"] = (
+      (if ($update | type) == "array" then $update
+      elif ($update | type) == "string" then [$update]
+      else [] end) as $commands |
+      if ($commands | index($cmd)) then $commands else $commands + [$cmd] end
+    )
+  ' "${COMPOSER_JSON}" >"${tmp}"
+
+  mv "${tmp}" "${COMPOSER_JSON}"
+}
+
+write_baseline() {
+  direct_package_names >"${BASELINE_PATH}"
+}
+
+sync_list() {
+  if [ ! -f "${BASELINE_PATH}" ]; then
+    echo "Skipping extension sync because ${BASELINE_PATH} is missing" >&2
+    return
+  fi
+
+  mkdir -p "$(dirname "${LIST_PATH}")"
+  tmp_dir=$(dirname "${LIST_PATH}")
+  tmp_name=$(basename "${LIST_PATH}").XXXXXX
+  tmp=$(mktemp -p "${tmp_dir}" "${tmp_name}")
+
+  direct_package_specs | while IFS= read -r spec; do
+    package="${spec%%:*}"
+    if grep -Fxq "${package}" "${BASELINE_PATH}"; then
+      continue
+    fi
+    echo "${spec}"
+  done | sort -u >"${tmp}"
+
+  mv "${tmp}" "${LIST_PATH}"
+}
+
+require_packages() {
+  [ "$#" -gt 0 ] || {
+    usage
+    exit 1
+  }
+
+  cd "${BASE_PATH}" || exit 1
+
+  for package in "$@"; do
+    case "${package}" in
+      *:*) ;;
+      *) package="${package}:*" ;;
+    esac
+
+    composer_require "${package}"
+    sync_as_flarum
+    echo "${package} extension added"
+  done
+
+  run_as_flarum php flarum cache:clear
+}
+
+remove_packages() {
+  [ "$#" -gt 0 ] || {
+    usage
+    exit 1
+  }
+
+  cd "${BASE_PATH}" || exit 1
+
+  for package in "$@"; do
+    package="${package%%:*}"
+    composer_remove "${package}"
+    sync_as_flarum
+    echo "${package} extension removed"
+  done
+
+  run_as_flarum php flarum cache:clear
+}
+
+action=${1:-}
+if [ -z "${action}" ]; then
+  usage
+  exit 1
+fi
 shift
 
 case "${action}" in
   "require")
-    for package in "$@"; do
-      COMPOSER_CACHE_DIR=${EXTS_CACHE_DIR} gosu flarum:flarum composer require "${package}"
-      if [ $? -eq 0 ]; then
-        echo "${package}" >> "${EXTS_LIST}"
-        echo "${package} extension added"
-        sort -u -o "${EXTS_LIST}" "${EXTS_LIST}"
-      else
-        echo "ERROR: cannot add ${package} extension"
-      fi
-    done
+    require_packages "$@"
     ;;
   "remove")
-    for package in "$@"; do
-      COMPOSER_CACHE_DIR=${EXTS_CACHE_DIR} gosu flarum:flarum composer remove "${package}"
-      if [ $? -eq 0 ]; then
-        sed -i "\|${package}|d" "${EXTS_LIST}"
-        echo "${package} extension removed"
-      else
-        echo "ERROR: cannot remove ${package} extension"
-      fi
-    done
+    remove_packages "$@"
+    ;;
+  "sync")
+    sync_as_flarum
     ;;
   "list")
-    cat "${EXTS_LIST}"
+    if [ -f "${LIST_PATH}" ]; then
+      cat "${LIST_PATH}"
+    fi
+    ;;
+  "baseline")
+    write_baseline
+    ;;
+  "install-hook")
+    install_hook
     ;;
   *)
-    echo "Usage:"
-    echo "extension require <package> [<package>...]"
-    echo "extension remove <package> [<package>...]"
-    echo "extension list"
+    usage
     exit 1
     ;;
 esac
-
-gosu flarum:flarum php flarum cache:clear

--- a/rootfs/usr/local/bin/flarum_scheduler
+++ b/rootfs/usr/local/bin/flarum_scheduler
@@ -5,6 +5,6 @@ cd /opt/flarum || exit 1
 
 if [ "$(id -u)" -eq 0 ]; then
   exec gosu flarum:flarum php flarum schedule:run --no-interaction
+else
+  exec php flarum schedule:run --no-interaction
 fi
-
-exec php flarum schedule:run --no-interaction


### PR DESCRIPTION
fixes https://github.com/crazy-max/docker-flarum/issues/103
fixes https://github.com/crazy-max/docker-flarum/issues/118
supersedes and closes https://github.com/crazy-max/docker-flarum/pull/151

This change persists additional Flarum Composer requirements through `/data/extensions/list` so extensions installed through the command line or Flarum Extension Manager survive container restarts and recreates.

The existing `extension` helper now installs a Composer post-install and post-update hook that regenerates `/data/extensions/list` from the root Composer requirements. Startup records the image baseline, replays persisted requirements from `/data/extensions/list`, and refreshes the list after Composer runs.

Flarum and Extension Manager both manage packages through Composer, so the root Composer requirements are the right source of truth. This keeps `/data` as the only persistence contract without persisting `composer.json`, `composer.lock`, or `vendor`, which preserves the image model while fixing extension loss after restart or upgrade.